### PR TITLE
SEAMJMS-26

### DIFF
--- a/impl/src/main/java/org/jboss/seam/jms/Seam3JmsExtension.java
+++ b/impl/src/main/java/org/jboss/seam/jms/Seam3JmsExtension.java
@@ -116,6 +116,9 @@ public class Seam3JmsExtension implements Extension {
             for (AnnotatedParameter<?> ap : m.getParameters()) {
                 log.debug("In method " + m.getJavaMember().getName() + " with param type " + ap.getBaseType());
             }
+            Class<?> intfClazz = m.getJavaMember().getDeclaringClass();
+            String methodName = m.getJavaMember().getName();
+            String routeId = intfClazz.getCanonicalName()+"."+methodName;
             Routing routing = null;
             if (m.isAnnotationPresent(Routing.class)) {
                 routing = m.getAnnotation(Routing.class);
@@ -123,7 +126,7 @@ public class Seam3JmsExtension implements Extension {
                 log.debug("Routing not found on method " + m.getJavaMember().getName());
             }
             RouteType routeType = (routing == null) ? RouteType.BOTH : routing.value();
-            Route route = new RouteImpl(routeType);
+            Route route = new RouteImpl(routeType).id(routeId);
             boolean isResourced = m.isAnnotationPresent(Resource.class);
             if (isResourced) {
                 Resource r = m.getAnnotation(Resource.class);

--- a/impl/src/test/java/org/jboss/seam/jms/test/locator/LocatorInterface.java
+++ b/impl/src/test/java/org/jboss/seam/jms/test/locator/LocatorInterface.java
@@ -1,0 +1,21 @@
+/*
+ * To change this template, choose Tools | Templates
+ * and open the template in the editor.
+ */
+
+package org.jboss.seam.jms.test.locator;
+
+import javax.enterprise.event.Observes;
+import javax.jms.Topic;
+import org.jboss.seam.jms.annotations.JmsDestination;
+import org.jboss.seam.jms.annotations.Routing;
+import org.jboss.seam.jms.bridge.RouteType;
+
+/**
+ *
+ * @author johnament
+ */
+public interface LocatorInterface {
+    @Routing(RouteType.EGRESS)
+    public void obsStringToTopic(@Observes String s, @JmsDestination(jndiName="jms/T2") Topic t);
+}

--- a/impl/src/test/java/org/jboss/seam/jms/test/locator/LocatorTest.java
+++ b/impl/src/test/java/org/jboss/seam/jms/test/locator/LocatorTest.java
@@ -1,0 +1,54 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.seam.jms.test.locator;
+
+import java.util.List;
+import javax.inject.Inject;
+import org.jboss.arquillian.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.seam.jms.annotations.Routing;
+import org.jboss.seam.jms.bridge.Route;
+import org.jboss.seam.jms.bridge.RouteLocator;
+import org.jboss.seam.jms.bridge.RouteType;
+import org.jboss.seam.jms.test.Util;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ *
+ * @author johnament
+ */
+@RunWith(Arquillian.class)
+public class LocatorTest {
+    @Inject RouteLocator routeLocator;
+    @Inject @Routing(RouteType.EGRESS) List<Route> egressRoutes;
+    @Inject @Routing(RouteType.INGRESS) List<Route> ingressRoutes;
+    	@Deployment
+    public static Archive<?> createDeployment() {
+        return Util.createDeployment(RouteLocator.class,LocatorInterface.class);
+    }
+
+    @Test
+    public void testLocatorVerify() {
+        Route route = routeLocator.findById(LocatorInterface.class.getCanonicalName()+"."+"obsStringToTopic");
+        Assert.assertNotNull(route);
+        Assert.assertEquals("Failed size match", egressRoutes.size(), 1, 0);
+        Assert.assertEquals("Failed size match", ingressRoutes.size(), 0, 0);
+    }
+}


### PR DESCRIPTION
SEAMJMS-26 Added support for a RouteLocator API allowing applications to look up routes, for the purpose of disabling them.
