### PR TITLE
upgrade to solder beta2, impl test fixes

### DIFF
--- a/api/src/main/java/org/jboss/seam/jms/AbstractMessageListener.java
+++ b/api/src/main/java/org/jboss/seam/jms/AbstractMessageListener.java
@@ -20,7 +20,7 @@ import javax.enterprise.inject.spi.BeanManager;
 import javax.jms.JMSException;
 import javax.jms.Message;
 
-import org.jboss.seam.solder.logging.Logger;
+import org.jboss.seam.logging.Logger;
 
 /**
  * Supporting base MessageListener for working in CDI enabled environments.

--- a/api/src/main/java/org/jboss/seam/jms/inject/JmsConnectionFactoryProducer.java
+++ b/api/src/main/java/org/jboss/seam/jms/inject/JmsConnectionFactoryProducer.java
@@ -23,7 +23,7 @@ import javax.jms.ConnectionFactory;
 import javax.naming.Context;
 import javax.naming.NamingException;
 
-import org.jboss.seam.solder.logging.Logger;
+import org.jboss.seam.logging.Logger;
 import org.jboss.seam.jms.annotations.JmsDefault;
 
 @ApplicationScoped

--- a/api/src/main/java/org/jboss/seam/jms/inject/JmsConnectionProducer.java
+++ b/api/src/main/java/org/jboss/seam/jms/inject/JmsConnectionProducer.java
@@ -23,7 +23,7 @@ import javax.jms.Connection;
 import javax.jms.ConnectionFactory;
 import javax.jms.JMSException;
 
-import org.jboss.seam.solder.logging.Logger;
+import org.jboss.seam.logging.Logger;
 import org.jboss.seam.jms.annotations.JmsDefault;
 
 public class JmsConnectionProducer {

--- a/examples/jms-statuswatcher/src/main/java/org/jboss/seam/jms/example/statuswatcher/messagedriven/DistributorMDB.java
+++ b/examples/jms-statuswatcher/src/main/java/org/jboss/seam/jms/example/statuswatcher/messagedriven/DistributorMDB.java
@@ -16,7 +16,7 @@ import javax.jms.Topic;
 import javax.jms.TopicPublisher;
 import javax.jms.TopicSession;
 
-import org.jboss.seam.solder.logging.Logger;
+import org.jboss.seam.logging.Logger;
 import org.jboss.seam.jms.example.statuswatcher.model.Status;
 import org.jboss.seam.jms.example.statuswatcher.session.StatusManager;
 

--- a/examples/jms-statuswatcher/src/main/java/org/jboss/seam/jms/example/statuswatcher/session/ReceivingClient.java
+++ b/examples/jms-statuswatcher/src/main/java/org/jboss/seam/jms/example/statuswatcher/session/ReceivingClient.java
@@ -12,7 +12,7 @@ import javax.faces.event.ValueChangeEvent;
 import javax.inject.Inject;
 import javax.inject.Named;
 
-import org.jboss.seam.solder.logging.Logger;
+import org.jboss.seam.logging.Logger;
 import org.jboss.seam.jms.TopicBuilder;
 import org.jboss.seam.jms.example.statuswatcher.model.Status;
 

--- a/examples/jms-statuswatcher/src/main/java/org/jboss/seam/jms/example/statuswatcher/session/ReceivingClientListener.java
+++ b/examples/jms-statuswatcher/src/main/java/org/jboss/seam/jms/example/statuswatcher/session/ReceivingClientListener.java
@@ -5,7 +5,7 @@ import javax.jms.JMSException;
 import javax.jms.Message;
 import javax.jms.ObjectMessage;
 
-import org.jboss.seam.solder.logging.Logger;
+import org.jboss.seam.logging.Logger;
 import org.jboss.seam.jms.AbstractMessageListener;
 import org.jboss.seam.jms.example.statuswatcher.model.Status;
 

--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -52,13 +52,18 @@
         </dependency>
         <dependency>
             <groupId>org.jboss.arquillian.junit</groupId>
-            <artifactId>arquillian-junit-core</artifactId>
-	   <scope>test</scope>
+            <artifactId>arquillian-junit-container</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
            <groupId>org.jboss.arquillian.container</groupId>
            <artifactId>arquillian-container-test-api</artifactId>
-	   <scope>test</scope>
+           <scope>test</scope>
+        </dependency>
+        <dependency>
+           <groupId>org.jboss.shrinkwrap.resolver</groupId>
+           <artifactId>shrinkwrap-resolver-impl-maven</artifactId>
+           <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/impl/src/main/java/org/jboss/seam/jms/DurableMessageManagerImpl.java
+++ b/impl/src/main/java/org/jboss/seam/jms/DurableMessageManagerImpl.java
@@ -12,7 +12,7 @@ import javax.jms.Session;
 import javax.jms.Topic;
 import javax.jms.TopicSubscriber;
 
-import org.jboss.seam.solder.logging.Logger;
+import org.jboss.seam.logging.Logger;
 import org.jboss.seam.jms.annotations.Durable;
 import org.jboss.seam.jms.annotations.JmsDefault;
 

--- a/impl/src/main/java/org/jboss/seam/jms/JmsMessageImpl.java
+++ b/impl/src/main/java/org/jboss/seam/jms/JmsMessageImpl.java
@@ -23,7 +23,7 @@ import java.util.Map;
 
 import javax.jms.Destination;
 
-import org.jboss.seam.solder.logging.Logger;
+import org.jboss.seam.logging.Logger;
 
 public class JmsMessageImpl implements JmsMessage {
 	private MessageManager messageManager;

--- a/impl/src/main/java/org/jboss/seam/jms/MessageManagerImpl.java
+++ b/impl/src/main/java/org/jboss/seam/jms/MessageManagerImpl.java
@@ -28,7 +28,7 @@ import javax.naming.Context;
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
 
-import org.jboss.seam.solder.logging.Logger;
+import org.jboss.seam.logging.Logger;
 import org.jboss.seam.jms.annotations.JmsDefault;
 
 @Dependent

--- a/impl/src/main/java/org/jboss/seam/jms/QueueBuilderImpl.java
+++ b/impl/src/main/java/org/jboss/seam/jms/QueueBuilderImpl.java
@@ -13,7 +13,7 @@ import javax.jms.Session;
 import javax.jms.TopicPublisher;
 import javax.jms.TopicSubscriber;
 
-import org.jboss.seam.solder.logging.Logger;
+import org.jboss.seam.logging.Logger;
 
 public class QueueBuilderImpl implements QueueBuilder {
 

--- a/impl/src/main/java/org/jboss/seam/jms/Seam3JmsExtension.java
+++ b/impl/src/main/java/org/jboss/seam/jms/Seam3JmsExtension.java
@@ -38,7 +38,7 @@ import javax.inject.Inject;
 import javax.inject.Qualifier;
 import javax.jms.Destination;
 
-import org.jboss.seam.solder.logging.Logger;
+import org.jboss.seam.logging.Logger;
 import org.jboss.seam.jms.annotations.EventRouting;
 import org.jboss.seam.jms.annotations.Inbound;
 import org.jboss.seam.jms.annotations.Outbound;

--- a/impl/src/main/java/org/jboss/seam/jms/TopicBuilderImpl.java
+++ b/impl/src/main/java/org/jboss/seam/jms/TopicBuilderImpl.java
@@ -12,7 +12,7 @@ import javax.jms.Topic;
 import javax.jms.TopicPublisher;
 import javax.jms.TopicSubscriber;
 
-import org.jboss.seam.solder.logging.Logger;
+import org.jboss.seam.logging.Logger;
 
 public class TopicBuilderImpl implements TopicBuilder {
 

--- a/impl/src/main/java/org/jboss/seam/jms/bridge/EgressRoutingObserver.java
+++ b/impl/src/main/java/org/jboss/seam/jms/bridge/EgressRoutingObserver.java
@@ -34,7 +34,7 @@ import javax.naming.Context;
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
 
-import org.jboss.seam.solder.logging.Logger;
+import org.jboss.seam.logging.Logger;
 import org.jboss.seam.jms.MessageManager;
 import org.jboss.seam.jms.Seam3JmsExtension;
 import org.jboss.seam.jms.annotations.OutboundLiteral;

--- a/impl/src/main/java/org/jboss/seam/jms/bridge/IngressMessageListener.java
+++ b/impl/src/main/java/org/jboss/seam/jms/bridge/IngressMessageListener.java
@@ -27,7 +27,7 @@ import javax.jms.Message;
 import javax.jms.ObjectMessage;
 import javax.jms.TextMessage;
 
-import org.jboss.seam.solder.logging.Logger;
+import org.jboss.seam.logging.Logger;
 import org.jboss.seam.jms.AbstractMessageListener;
 import org.jboss.seam.jms.annotations.InboundLiteral;
 

--- a/impl/src/main/java/org/jboss/seam/jms/bridge/JmsMessageObserver.java
+++ b/impl/src/main/java/org/jboss/seam/jms/bridge/JmsMessageObserver.java
@@ -24,7 +24,7 @@ import javax.jms.Destination;
 import javax.jms.JMSException;
 import javax.jms.Message;
 
-import org.jboss.seam.solder.logging.Logger;
+import org.jboss.seam.logging.Logger;
 import org.jboss.seam.jms.JmsMessage;
 import org.jboss.seam.jms.MessageManager;
 

--- a/impl/src/main/java/org/jboss/seam/jms/bridge/RouteBuilderImpl.java
+++ b/impl/src/main/java/org/jboss/seam/jms/bridge/RouteBuilderImpl.java
@@ -27,7 +27,7 @@ import javax.jms.Destination;
 import javax.jms.JMSException;
 import javax.servlet.ServletContext;
 
-import org.jboss.seam.solder.logging.Logger;
+import org.jboss.seam.logging.Logger;
 import org.jboss.seam.jms.MessageManager;
 import org.jboss.seam.jms.Seam3JmsExtension;
 

--- a/impl/src/main/java/org/jboss/seam/jms/bridge/RouteImpl.java
+++ b/impl/src/main/java/org/jboss/seam/jms/bridge/RouteImpl.java
@@ -34,7 +34,7 @@ import javax.naming.Context;
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
 
-import org.jboss.seam.solder.logging.Logger;
+import org.jboss.seam.logging.Logger;
 import org.jboss.seam.solder.bean.ImmutableInjectionPoint;
 
 /**

--- a/impl/src/main/java/org/jboss/seam/jms/tools/JMSResourceManager.java
+++ b/impl/src/main/java/org/jboss/seam/jms/tools/JMSResourceManager.java
@@ -28,7 +28,7 @@ import javax.jms.MessageConsumer;
 import javax.jms.QueueReceiver;
 import javax.jms.TopicSubscriber;
 
-import org.jboss.seam.solder.logging.Logger;
+import org.jboss.seam.logging.Logger;
 import org.jboss.seam.jms.annotations.Closeable;
 
 /**

--- a/impl/src/test/java/org/jboss/seam/jms/test/Util.java
+++ b/impl/src/test/java/org/jboss/seam/jms/test/Util.java
@@ -24,17 +24,16 @@ import org.jboss.seam.jms.bridge.Route;
 import org.jboss.seam.jms.impl.inject.SessionProducer;
 import org.jboss.seam.jms.inject.JmsConnectionProducer;
 import org.jboss.seam.jms.test.bridge.IngressInterfaceProducer;
-import org.jboss.seam.solder.core.VersionLoggerUtil;
-import org.jboss.seam.solder.reflection.AnnotationInspector;
-import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.resolver.api.DependencyResolvers;
+import org.jboss.shrinkwrap.resolver.api.maven.MavenDependencyResolver;
 
 public class Util {
     public static final String HORNETQ_JMS_DEPLOYMENT_CONFIG = "hornetq-jms.xml";
-
+    
     public static WebArchive createDeployment(Class<?>... classes) {
         JavaArchive ejbModule = ShrinkWrap.create(JavaArchive.class, "test.jar");
         ejbModule.addPackage(Util.class.getPackage());
@@ -43,7 +42,7 @@ public class Util {
         ejbModule.addPackage(SessionProducer.class.getPackage());
         ejbModule.addPackage(JmsConnectionProducer.class.getPackage());
         ejbModule.addPackage(Route.class.getPackage());
-        ejbModule.addClasses(IngressInterfaceProducer.class,VersionLoggerUtil.class, AnnotationInspector.class);
+        ejbModule.addClasses(IngressInterfaceProducer.class);
         ejbModule.addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
         ejbModule.addAsServiceProvider(Extension.class, Seam3JmsExtension.class);
         for (Class<?> c : classes) {
@@ -52,6 +51,12 @@ public class Util {
         WebArchive war = ShrinkWrap.create(WebArchive.class, "test.war");
         war.addAsLibraries(ejbModule);
         war.addAsWebInfResource(HORNETQ_JMS_DEPLOYMENT_CONFIG, HORNETQ_JMS_DEPLOYMENT_CONFIG);
+        
+        war.addAsLibraries(DependencyResolvers.use(MavenDependencyResolver.class)
+                .loadReposFromPom("pom.xml")
+                .artifact("org.jboss.seam.solder:seam-solder")
+                .resolveAs(JavaArchive.class));
+        
         // TODO Add this conditionally based on test profile to support other containers
         return war;
     }

--- a/impl/src/test/resources-jbossas/arquillian.xml
+++ b/impl/src/test/resources-jbossas/arquillian.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<arquillian xmlns="http://jboss.com/arquillian" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://jboss.org/schema/arquillian http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
+
+    <!-- engine>
+       <property name="deploymentExportPath">target/</property>
+    </engine -->
+
+    <container qualifier="jbossas6" default="true">
+        <configuration>
+            <property name="javaVmArguments">-Xmx1024m -XX:MaxPermSize=512m</property>
+        </configuration>
+    </container>
+
+</arquillian>
+

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.seam</groupId>
         <artifactId>seam-parent</artifactId>
-        <version>12</version>
+        <version>14</version>
     </parent>
 
     <groupId>org.jboss.seam.jms</groupId>
@@ -17,8 +17,7 @@
     <url>http://sfwk.org/Seam3/JMS</url>
 
     <properties>
-        <seam.version>3.1.0.Beta1</seam.version>
-        <arquillian.version>1.0.0.CR2</arquillian.version>
+        <seam.version>3.1.0.Beta2</seam.version>
         <emma.version>2.0.5312</emma.version>
     </properties>
 


### PR DESCRIPTION
1. Changes in pom (seam parent to 14, seam.version to 3.1.0.Beta2)
2. Update org.jboss.seam.solder.logging.Logger to org.jboss.seam.logging.Logger
3. Use MavenDependencyResolver to get the whole Solder in tests to make them working again on AS6.
