### PR TITLE
Fixed SEAMJMS-55

### DIFF
--- a/impl/src/main/java/org/jboss/seam/jms/MessageManagerImpl.java
+++ b/impl/src/main/java/org/jboss/seam/jms/MessageManagerImpl.java
@@ -146,7 +146,7 @@ public class MessageManagerImpl implements MessageManager {
 
     private void sendMessage(Destination destination, Message message) {
         try {
-            logger.info("Routing destionation " + destination + " with message " + message);
+            logger.info("Routing destination " + destination + " with message " + message);
             this.createMessageProducer(destination).send(message);
         } catch (JMSException e) {
             logger.warn("Problem attempting to send message " + message + " to destination " + destination, e);

--- a/testsuite/jbossas7.cli
+++ b/testsuite/jbossas7.cli
@@ -9,4 +9,5 @@ add-jms-queue --name=Q --entries=jms/Q
 add-jms-queue --name=QC --entries=jms/QC
 add-jms-queue --name=QB --entries=jms/QB
 add-jms-queue --name=QA --entries=jms/QA
+add-jms-queue --name=RouteTest --entries=jms/RouteTest
 run-batch

--- a/testsuite/readme.md
+++ b/testsuite/readme.md
@@ -15,7 +15,7 @@
     mvn clean verify -Darquillian=jbossas-remote-7
     
 ##Running the testsuite on JBoss AS 6
-    export JBOSS_HOME=/path/to/jboss-as-7.x
+    export JBOSS_HOME=/path/to/jboss-as-6.x
     
     Disable security.  See [SEAMJMS-13](https://issues.jboss.org/browse/SEAMJMS-13) for more information.
     sed '/<\/address-settings>/a<security-enabled>false</security-enabled>' -i ${JBOSS_HOME}/server/default/deploy/hornetq/hornetq-configuration.xml

--- a/testsuite/src/test/java/org/jboss/seam/jms/test/bridge/route/RouteTest.java
+++ b/testsuite/src/test/java/org/jboss/seam/jms/test/bridge/route/RouteTest.java
@@ -69,7 +69,7 @@ public class RouteTest {
     @Test
     public void forwardSimpleEvent() throws JMSException {
         String expected = "'configured via Collection<Route>'";
-        QueueReceiver qr = messageManager.createQueueReceiver("queue/DLQ");
+        QueueReceiver qr = messageManager.createQueueReceiver("jms/RouteTest");
         clear(qr);
         event_viaCollectionRouteConfig.fire(expected);
         Message m = qr.receive(3000);
@@ -82,7 +82,7 @@ public class RouteTest {
     @Test
     public void noMatchingRoutes() throws JMSException {
         String expected = "'no matching route'";
-        QueueReceiver qr = messageManager.createQueueReceiver("queue/DLQ");
+        QueueReceiver qr = messageManager.createQueueReceiver("jms/RouteTest");
         clear(qr);
         plainEvent.fire(expected);
         Message m = qr.receive(3000);
@@ -93,7 +93,7 @@ public class RouteTest {
     @Test
     public void forwardSimpleEvent_via_single_route_config() throws JMSException {
         String expected = "'configured via Route'";
-        QueueReceiver qr = messageManager.createQueueReceiver("queue/DLQ");
+        QueueReceiver qr = messageManager.createQueueReceiver("jms/RouteTest");
         clear(qr);
         event_viaSingleRouteConfig.fire(expected);
         Message m = qr.receive(3000);

--- a/testsuite/src/test/java/org/jboss/seam/jms/test/bridge/route/RoutingConfig.java
+++ b/testsuite/src/test/java/org/jboss/seam/jms/test/bridge/route/RoutingConfig.java
@@ -30,7 +30,7 @@ import org.jboss.seam.jms.bridge.RouteManager;
 import static org.jboss.seam.jms.bridge.RouteType.EGRESS;
 
 public class RoutingConfig {
-    @Resource(mappedName = "queue/DLQ")
+    @Resource(mappedName = "jms/RouteTest")
     Queue q;
 
     private static final AnnotationLiteral<BridgedViaCollection> BRIDGED_VIA_COLLECTION = new AnnotationLiteral<BridgedViaCollection>() {
@@ -43,11 +43,13 @@ public class RoutingConfig {
 
     @EventRouting
     public Collection<Route> getRoutes(RouteManager routeManager) {
-        return Arrays.asList(routeManager.createRoute(EGRESS, String.class).addQualifiers(BRIDGED_VIA_COLLECTION).addDestinationJndiName("queue/DLQ"));
+        return Arrays.asList(routeManager.createRoute(EGRESS, String.class).addQualifiers(BRIDGED_VIA_COLLECTION)
+          .addDestinationJndiName("jms/RouteTest"));
     }
 
     @EventRouting
     public Route getRoute(RouteManager routeManager) {
-        return routeManager.createRoute(EGRESS, String.class).addQualifiers(BRIDGED_VIA_ROUTE).addDestinationJndiName("queue/DLQ");
+        return routeManager.createRoute(EGRESS, String.class).addQualifiers(BRIDGED_VIA_ROUTE).addDestinationJndiName
+          ("jms/RouteTest");
     }
 }

--- a/testsuite/src/test/resources-jbossas6/hornetq-jms.xml
+++ b/testsuite/src/test/resources-jbossas6/hornetq-jms.xml
@@ -52,4 +52,8 @@
         <queue name="QA">
         <entry name="/jms/QA"/>
     </queue>
+
+    <queue name="RouteTest">
+      <entry name="/jms/RouteTest"/>
+    </queue>
 </configuration>


### PR DESCRIPTION
Tested on JBoss AS 6.0.0.Final and 7.0.2.Final. The fix is to create a new queue to use for the routing tests instead of assuming a DLQ by the name 'jms/DLQ' exists.
